### PR TITLE
Add `ember generate service-worker` blueprint.

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/service-worker/index.js
+++ b/blueprints/service-worker/index.js
@@ -1,0 +1,8 @@
+/*jshint node:true*/
+
+module.exports = {
+  description: 'Generate a service-worker folder to be used with ember-service-worker addon.',
+
+  // Do not require a name
+  normalizeEntityName: function() { }
+};


### PR DESCRIPTION
Doesn't do much, but gives us a nice way to add some common setup stuff
in the future.  For example, I'd like to add an `service-worker/.eslintrc.js`
to instruct ESLint to use the `serviceworker` environment.

**Note:** This does not make `ember install ember-service-worker` add a
  service worker to the project itself. I do not believe that we want
  this behavior. I believe we would prefer projects to simply add the
  various plugins they need, but not *require* dropping down and writing
  their own service worker code.