### PR TITLE
Allow service-worker to be scoped to `rootURL`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,10 @@ module.exports = {
 
   contentFor: function(type, config) {
     if (type === 'body-footer' && config.environment !== 'test') {
-      var functionBody = fs.readFileSync(path.join(this.root, 'lib/registration.js'));
+      var rootURL = config.rootURL || config.baseURL || '/';
+      var functionBody = fs.readFileSync(path.join(this.root, 'lib/registration.js'), { encoding: 'utf8' });
+
+      functionBody = functionBody.replace(/{{rootURL}}/g, rootURL);
       return '<script>' + functionBody + '</script>';
     }
   },

--- a/lib/registration.js
+++ b/lib/registration.js
@@ -1,6 +1,6 @@
 (function() {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js', { scope: '/' }).then(function(reg) {
+    navigator.serviceWorker.register('/sw.js', { scope: '{{rootURL}}' }).then(function(reg) {
       console.log('Service Worker registration succeeded. Scope is ' + reg.scope);
     }).catch(function(error) {
       console.log('Service Worker registration failed with ' + error);


### PR DESCRIPTION
By default, this changes nothing (`rootURL` defaults to `/`), but if a custom `rootURL` is being used by the application this will dutifully use that path as the scope.

Fixes https://github.com/DockYard/ember-service-worker/issues/27.