### PR TITLE
Enable customizable registration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ To create an Ember Service Worker plugin, you first need to add the
 `ember-service-worker-plugin` keyword to the `keywords` option in the plugin's
 `package.json`
 
-Then create an `service-worker/index.js` file within in the root of your addon. This file will
+From within a service worker plugin, you can modify the contents of the generated service worker
+(built to `dist/sw.js`) and/or you can modify the mechanism of service worker registration ( built
+to `dist/sw-registration.js`).
+
+## Service Worker Tree
+
+Create a `service-worker/index.js` file within in the root of your addon. This file will
 automatically be loaded by the created service worker.
 
 Other files in the `service-worker` file are available for `import` via standard ES6 module
@@ -85,10 +91,52 @@ self.addEventListener('install', function(event) {
 });
 ```
 
+## Service Worker Registration Tree
+
+Create a `service-worker-registration/index.js` file within the root of your addon. This file
+is required to register the service worker (and its scope).
+
+Other files in the `service-worker-registration` file are available for `import` via standard
+ES6 module semantics.
+
+### API
+
+#### `addSuccessHandler`
+
+You can use this method to register a callback to execute after registration is successful.
+The callback will be passed the `registration` object.
+
+Example:
+
+```js
+import { addSuccessHandler } from 'ember-service-worker/service-worker-registration';
+
+addSuccessHandler(function(reg) {
+  // do stuff on successful registration
+});
+```
+
+#### `addErrroHandler`
+
+You can use this method to register a callback to execute if registration has errored.
+The callback will be passed the `registration` object.
+
+Example:
+
+```js
+import { addErrorHandler } from 'ember-service-worker/service-worker-registration';
+
+addErrorHandler(function(reg) {
+  // do stuff on errored registration
+});
+```
+
 ## Adding Service Worker code directly to your app
 
 It is also possible to add service worker code to your app directly. To do this
-add a `service-worker/index.js` file in the root of your project.
+add a `service-worker/index.js` or `service-worker-registration/index.js` file to
+your project.
+
 This works exactly as authoring plugins.
 
 ## Authors

--- a/lib/registration.js
+++ b/lib/registration.js
@@ -1,9 +1,0 @@
-(function() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js', { scope: '{{rootURL}}' }).then(function(reg) {
-      console.log('Service Worker registration succeeded. Scope is ' + reg.scope);
-    }).catch(function(error) {
-      console.log('Service Worker registration failed with ' + error);
-    });
-  }
-})();

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
       "ember": ">1.13.0 <3.0.0"
-    }
+    },
+    "before": ["ember-cli-sri"]
   }
 }

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -1,0 +1,43 @@
+let SUCCESS_HANDLERS = [];
+let ERROR_HANDLERS = [];
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('{{ROOT_URL}}sw.js', { scope: '{{ROOT_URL}}' })
+    .then(function(reg) {
+      let current = new Promise.resolve();
+
+      for (let i = 0; i < SUCCESS_HANDLERS.length; i++) {
+        current = current.then(function() {
+          return SUCCESS_HANDLERS[i](reg);
+        });
+      }
+
+      return current
+        .then(function() {
+          console.log('Service Worker registration succeeded. Scope is ' + reg.scope);
+        });
+    })
+    .catch(function(error) {
+      let current = new Promise.resolve();
+
+      for (let i = 0; i < ERROR_HANDLERS.length; i++) {
+        current = current.then(function() {
+          return ERROR_HANDLERS[i](error);
+        });
+      }
+
+      return current
+        .then(function() {
+          console.log('Service Worker registration failed with ' + error);
+        });
+    });
+}
+
+
+export function addSuccessHandler(func) {
+  SUCCESS_HANDLERS.push(func);
+}
+
+export function addErrorHandler(func) {
+  ERROR_HANDLERS.push(func);
+}


### PR DESCRIPTION
Allows plugins to augment the registration process via a new `service-worker-registration` tree.

To perform its own operations upon registration, a plugin need only have the following:

* `ember-service-worker-plugin` keyword 
* `service-worker-registration/index.js` file with a snippet like the following:

```
import { addSuccessHandler } from 'ember-service-worker/service-worker-registration';

addSuccessHandler((reg) => {
  // do stuff!
});
```

See #31 for some additional background / motivation on this.

Closes #31
