### PR TITLE
Provide `PROJECT_REVISION`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ self.addEventListener('install', function(event) {
 });
 ```
 
+#### `PROJECT_REVISION`
+
+This is a constant that you can utilize which is tied to the project (and all
+levels of dependencies). One use case for this, is to ensure that the service worker
+in use is paired with the correct project:
+
+```js
+import { PROJECT_REVISION } from 'ember-service-worker/service-worker';
+
+self.addEventListener('message', function(event) {
+  if (event.data && event.data.command === 'verify-project-revision') {
+    if (PROJECT_REVISION !== event.data.PROJECT_REVISION) {
+      // handle when the project revision doesn't match
+    }
+  }
+});
+```
+
 ## Service Worker Registration Tree
 
 Create a `service-worker-registration/index.js` file within the root of your addon. This file
@@ -128,6 +146,26 @@ import { addErrorHandler } from 'ember-service-worker/service-worker-registratio
 
 addErrorHandler(function(reg) {
   // do stuff on errored registration
+});
+```
+
+#### `PROJECT_VERSION`
+
+This is a constant that you can utilize which is tied to the project (and all
+levels of dependencies). One use case for this, is to ensure that the service worker
+in use is paired with the correct project:
+
+```js
+import { addSuccessHandler, PROJECT_REVISION } from 'ember-service-worker/service-worker-registration';
+
+addSuccessHandler(function(reg) {
+  return navigator.serviceWorker.ready
+    .then(function() {
+      navigator.serviceWorker.controller.postMessage({
+        command: 'verify-project-revision',
+        revision: PROJECT_REVISION
+      });
+    });
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -11,17 +11,21 @@ var Rollup = require('./lib/rollup-with-dependencies');
 var rollupReplace = require('rollup-plugin-replace');
 var Funnel = require('broccoli-funnel');
 var existsSync = require('exists-sync');
+var hashForDep = require('hash-for-dep');
 
 module.exports = {
   name: 'ember-service-worker',
 
   included: function(app) {
     this._super.included && this._super.included.apply(this, arguments);
+
     this.app = app;
     this.app.options = this.app.options || {};
     this.app.options.fingerprint = this.app.options.fingerprint || {};
     this.app.options.fingerprint.exclude = this.app.options.fingerprint.exclude || [];
     this.app.options.fingerprint.exclude.push('sw.js');
+
+    this._projectVersion = hashForDep(this.project.root);
   },
 
   postprocessTree: function(type, tree) {
@@ -81,20 +85,17 @@ module.exports = {
     var rollupReplaceConfig = {
       include: ['**/ember-service-worker/**/*.js'],
       delimiters: ['{{', '}}'],
-      ROOT_URL: rootURL
-    };
+      ROOT_URL: rootURL,
+      PROJECT_REVISION: this._projectVersion,
 
-    // define `BUILD_TIME` as a getter so that each time
-    // rollup runs the version string is changed.  Otherwise,
-    // when running `ember s` this would never change (leading to
-    // cache invalidation trollage).
-    Object.defineProperty(rollupReplaceConfig, 'BUILD_TIME', {
-      enumerable: true,
-      configurable: true,
-      get: function() {
+      // define `BUILD_TIME` as a getter so that each time
+      // rollup runs the version string is changed.  Otherwise,
+      // when running `ember s` this would never change (leading to
+      // cache invalidation trollage).
+      get BUILD_TIME() {
         return (new Date()).getTime();
       }
-    });
+    };
 
     return new Rollup(tree, {
       inputFiles: '**/*.js',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "clone": "^1.0.2",
     "ember-cli-babel": "^5.1.6",
     "exists-sync": "0.0.3",
+    "hash-for-dep": "^1.0.2",
     "rollup-plugin-replace": "^1.1.1"
   },
   "ember-addon": {
@@ -62,6 +63,8 @@
     "versionCompatibility": {
       "ember": ">1.13.0 <3.0.0"
     },
-    "before": ["ember-cli-sri"]
+    "before": [
+      "ember-cli-sri"
+    ]
   }
 }

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -1,3 +1,5 @@
+export const PROJECT_REVISION = '{{PROJECT_REVISION}}';
+
 let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,3 +1,4 @@
+export const PROJECT_REVISION = '{{PROJECT_REVISION}}';
 export const VERSION = '{{BUILD_TIME}}';
 
 let FETCH_HANDLERS = [];


### PR DESCRIPTION
This will allow both `service-worker` and `service-worker-registration` to do different things based on the current revision.

There are at least two major use-cases for this:

* Allow caching to be busted (of things like `vendor.js`) to only be invalidated when the projects dependencies (and/or its sub-dependencies) are changed.
* Allow a plugin to ensure the service-worker and the registration success handler are paired together properly.

