### PR TITLE
`addFetchListener` tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ To make addons simple and pluggable, some middleware has been added.
 If you want to listen for `fetch` in your addon, you will need to register this
 through the `addFetchListener` function. This expects a callback function which
 receives the event as argument, just as the callback to
-`addEventListener('fetch', ...)` does. It expects the callback to return a
-Promise that resolves to a response or `undefined`. If the response is undefined
+`addEventListener('fetch', ...)` does. The callback can return a
+Promise that resolves to a response or it can return `undefined`. If the response is undefined
 the next `fetch` handler that has been registered will be called, otherwise the
 response from the promise will be used and no further `fetch` handlers will be
 called.

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -4,7 +4,7 @@ export const VERSION = '{{BUILD_TIME}}';
 let FETCH_HANDLERS = [];
 
 self.addEventListener('fetch', function fetchEventListenerCallback(event) {
-  var resolver = function fetchResolver(resolve, reject, index) {
+  let resolver = function fetchResolver(resolve, reject, index) {
     if (!index) {
       index = 0;
     }
@@ -14,9 +14,10 @@ self.addEventListener('fetch', function fetchEventListenerCallback(event) {
       return;
     }
 
-    var handler = FETCH_HANDLERS[index];
+    let handler = FETCH_HANDLERS[index];
+    let result = handler(event);
 
-    handler(event)
+    Promise.resolve(result)
       .then(function (response) {
         if (response) {
           return resolve(response);

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -11,6 +11,7 @@ self.addEventListener('fetch', function fetchEventListenerCallback(event) {
 
     if (index >= FETCH_HANDLERS.length) {
       resolve(fetch(event.request));
+      return;
     }
 
     var handler = FETCH_HANDLERS[index];


### PR DESCRIPTION
This PR introduced two changes, one fixes a bug and the other makes things a bit more ergonomic.


* Previously if none of the registered fetch handlers return something other than `undefined` we would hit this gaurd to resolve with the result of fetching the asset (which is good). Unfortunately, in that case, we would also continue execution and attempt to call `handler.then` when `handler` is known to be undefined. This change prevents that by returning early once we have resolved the fallback scenario.
* Previously you must return a promise from each callback added via `addFetchListener`.  This is somewhat cumbersome when adding guard statements (since you would have to do `if (cond) { return Promise.resolve(undefined); }`. This change allows the handler to return `undefined` or a promise resolving to `undefined` (or falsey).