### PR TITLE
Set the project root based on ENV.

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports = {
       return this._projectRootURL;
     }
 
-    var config = this.project.config();
+    var config = this.project.config(this.app.env);
     var rootURL = config.rootURL || config.baseURL || '/';
 
     return this._projectRootURL = rootURL;


### PR DESCRIPTION
Currently, if you set a different `rootURL` for `environment === 'production'`, `ember-service-worker` won't respect that. Passing in the environment fixes it.

For example:

https://github.com/yaymukund/example-app-that-breaks-ember-service-worker/blob/master/config/environment.js#L45-L47
https://github.com/yaymukund/example-app-that-breaks-ember-service-worker/blob/master/dist/index.html#L24