### PR TITLE
Make rootURL configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,8 +64,9 @@ module.exports = {
       return this._projectRootURL;
     }
 
+    let customOptions = this.app.options['ember-service-worker'] || {};
     let config = this.project.config(this.app.env);
-    let rootURL = config.rootURL || config.baseURL || '/';
+    let rootURL = customOptions.rootUrl || config.rootURL || config.baseURL || '/';
 
     return this._projectRootURL = rootURL;
   },


### PR DESCRIPTION
Hey :wave: I apologize for not opening an issue first, but maybe this change is minimal enough that you can consider it without one - I need to configure the `rootUrl`, since the service worker will actually end up living in a different folder. As background, we over at [Ghost](https://github.com/tryghost/ghost) have a somewhat clever integration of serving our Ember-powered admin interface through a custom server, so the Ember App's rootUrl is different from where JavaScript lives.

This tiny change allows users to override `rootURL` by adding a `ember-service-worker` section to the Ember CLI build configuration.