### PR TITLE
Added URL utils that help correct escaping of URL regexs

### DIFF
--- a/service-worker/url-utils.js
+++ b/service-worker/url-utils.js
@@ -1,0 +1,40 @@
+/**
+ * Create an absolute URL, allowing regex expressions to pass
+ *
+ * @param {string} url
+ * @param {string|object} baseUrl
+ * @public
+ */
+export function createNormalizedUrl(url, baseUrl = self.location) {
+  return decodeURI(new URL(encodeURI(url), baseUrl).toString());
+}
+
+/**
+ * Create an (absolute) URL Regex from a given string
+ *
+ * @param {string} url
+ * @returns {RegExp}
+ * @public
+ */
+export function createUrlRegEx(url) {
+  let normalized = createNormalizedUrl(url);
+  return new RegExp(`^${normalized}$`);
+}
+
+/**
+ * Check if given URL matches any pattern
+ *
+ * @param {string} url
+ * @param {array} patterns
+ * @returns {boolean}
+ * @public
+ */
+export function urlMatchesAnyPattern(url, patterns) {
+  return !!patterns.find((pattern) => pattern.test(decodeURI(url)));
+}
+
+export default {
+  createAbsoluteDomain,
+  createUrlRegEx,
+  urlMatchesAnyPattern
+}


### PR DESCRIPTION
`ember-service-worker-cache-fallback` and `ember-service-worker-cache-first` have issues handling URL patterns, as `new URL(...)` escapes some valid regular expression characters like '{', '}', '|' etc. See https://github.com/DockYard/ember-service-worker-cache-fallback/issues/11

The helper functions added here correctly handle these cases by using `encodeURI` / `decodeURI`. They are meant to be imported by the mentioned plugins, so we can share the code, see the other upcoming PRs...

Would be nice if we could add tests for them, but as they use browser APIs, we cannot just add test cases to the existing `node-tests`. Some PhantomJS based test setup would be needed for that, never have set this up by myself though...