### PR TITLE
Don't run sw.js through babel in non-minification envs

### DIFF
--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -72,7 +72,6 @@ module.exports = class ServiceWorkerBuilder {
     let entryPoint = new EntryPoint(trees, { entryPoint: `${treeName}` });
     let tree = mergeTrees(trees.concat(entryPoint), { overwrite: true });
 
-    tree = this._babelTranspile(tree);
     tree = this._rollupTree(tree, `${treeName}`);
     tree = this._uglifyTree(tree);
 
@@ -114,6 +113,7 @@ module.exports = class ServiceWorkerBuilder {
     if (this.options.minifyJS && this.options.minifyJS.enabled) {
       let options = this.options.minifyJS.options || {};
       options.sourceMapConfig = this.options.sourcemaps;
+      tree = this._babelTranspile(tree);
       return uglify(tree,  options);
     }
 

--- a/node-tests/service-worker-builder-test.js
+++ b/node-tests/service-worker-builder-test.js
@@ -61,26 +61,6 @@ describe('Service Worker Builder', () => {
       });
   });
 
-  it('transpiles code with babel', () => {
-    let plugins = [generatePlugin('test-project', 'builder-test/babel')];
-    return build({ app, plugins }, 'service-worker')
-      .then((results) => {
-        let expected = `
-(function () {
-  'use strict';
-
-  var CONSTANT = 42;
-  self.addEventListener('fetch', function () {
-    var x = CONSTANT + 1;
-  });
-
-}());
-`.trim();
-
-        assert.equal(readFile(results, 'sw.js'), expected);
-      });
-  });
-
   it('uses rollup to concat all modules in a file', () => {
     let plugins = [
       generatePlugin('plugin-a', 'builder-test/rollup/plugin-a'),
@@ -93,16 +73,17 @@ describe('Service Worker Builder', () => {
 (function () {
   'use strict';
 
-  var CONSTANT = 42;
+  const CONSTANT = 42;
 
-  self.addEventListener('fetch', function () {
-    var x = CONSTANT + 1;
+  self.addEventListener('fetch', function() {
+    let x = CONSTANT + 1;
   });
 
 }());
 `.trim();
 
-        assert.equal(readFile(results, 'sw.js'), expected);
+        let file = readFile(results, 'sw.js').toString('utf8');
+        assert.equal(file, expected);
       });
   });
 


### PR DESCRIPTION
Babel will cache sw.js and that cache cannot be busted unless the
original file on the file system changes. Because sw.js is not on the
file system it will never change. This means in development mode the
cache busting version string can never be updated.

This PR will move babel's transpilation step into the uglify step. Babel
is only required to satisfy uglify requiring ES5 for the time being.

Partially addresses #73 