### PR TITLE
Bring back broccoli-babel-transpiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,6 @@ module.exports = {
       appTree,
       minifyJS: this.app.options.minifyJS,
       plugins,
-      projectVersion: this.project.pkg.version,
-      projectRevision: hashForDep(this.project.root),
       rootURL: this._getRootURL(),
       sourcemaps: this.app.options.sourcemaps
     });
@@ -93,6 +91,9 @@ module.exports = {
 
   treeForServiceWorker(swTree, appTree) {
     var options = this.app.options['ember-service-worker'] || {};
+    options.projectVersion = this.project.pkg.version;
+    options.projectRevision = hashForDep(this.project.root);
+
     var indexFile = new IndexFile([appTree], options);
 
     return mergeTrees([swTree, indexFile]);

--- a/lib/index-file.js
+++ b/lib/index-file.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const Plugin = require('broccoli-plugin');
 const fs = require('fs');
 const path = require('path');
+const Plugin = require('broccoli-plugin');
 
-const BASE_MODULE = `
-  export const PROJECT_VERSION = '{{PROJECT_VERSION}}';
-  export const PROJECT_REVISION = '{{PROJECT_REVISION}}';
-  export const VERSION = '{{BUILD_TIME}}';
+function baseModule(options) {
+  return `
+  export const PROJECT_VERSION = '${options.projectVersion}';
+  export const PROJECT_REVISION = '${options.projectRevision}';
+  export const VERSION = '${options.buildTime}';
 
   self.addEventListener('install', function installEventListenerCallback(event) {
     return self.skipWaiting();
@@ -16,7 +17,7 @@ const BASE_MODULE = `
   self.addEventListener('activate', function installEventListenerCallback(event) {
     return self.clients.claim();
   });
-`;
+`; }
 
 const EVERY_BUILD_STRATEGY = `self.CACHE_BUSTER = VERSION;`;
 const PROJECT_REVISION_STRATEGY = `self.CACHE_BUSTER = PROJECT_REVISION;`;
@@ -34,7 +35,9 @@ module.exports = class Config extends Plugin {
 
   build() {
     let options = this.options;
-    let module = BASE_MODULE;
+    options.buildTime = (new Date).getTime() + '|' + Math.random();
+
+    let module = baseModule(options);
 
     if (options.versionStrategy === 'every-build') {
       module += EVERY_BUILD_STRATEGY;

--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -72,6 +72,7 @@ module.exports = class ServiceWorkerBuilder {
     let entryPoint = new EntryPoint(trees, { entryPoint: `${treeName}` });
     let tree = mergeTrees(trees.concat(entryPoint), { overwrite: true });
 
+    tree = this._babelTranspile(tree);
     tree = this._rollupTree(tree, `${treeName}`);
     tree = this._uglifyTree(tree);
 
@@ -82,17 +83,7 @@ module.exports = class ServiceWorkerBuilder {
     let rollupReplaceConfig = {
       include: ['**/ember-service-worker/**/*.js'],
       delimiters: ['{{', '}}'],
-      ROOT_URL: this.options.rootURL,
-      PROJECT_VERSION: this.options.projectVersion,
-      PROJECT_REVISION: this.options.projectRevision,
-
-      // define `BUILD_TIME` as a getter so that each time
-      // rollup runs the version string is changed.  Otherwise,
-      // when running `ember s` this would never change (leading to
-      // cache invalidation trollage).
-      get BUILD_TIME() {
-        return (new Date()).getTime();
-      }
+      ROOT_URL: this.options.rootURL
     };
 
     return new Rollup(tree, {
@@ -113,7 +104,6 @@ module.exports = class ServiceWorkerBuilder {
     if (this.options.minifyJS && this.options.minifyJS.enabled) {
       let options = this.options.minifyJS.options || {};
       options.sourceMapConfig = this.options.sourcemaps;
-      tree = this._babelTranspile(tree);
       return uglify(tree,  options);
     }
 

--- a/node-tests/service-worker-builder-test.js
+++ b/node-tests/service-worker-builder-test.js
@@ -61,6 +61,27 @@ describe('Service Worker Builder', () => {
       });
   });
 
+  it('transpiles code with babel', () => {
+    let plugins = [generatePlugin('test-project', 'builder-test/babel')];
+    return build({ app, plugins }, 'service-worker')
+      .then((results) => {
+        let expected = `
+(function () {
+  'use strict';
+
+  var CONSTANT = 42;
+  self.addEventListener('fetch', function () {
+    var x = CONSTANT + 1;
+  });
+
+}());
+`.trim();
+
+        let file = readFile(results, 'sw.js').toString('utf8');
+        assert.equal(file, expected);
+      });
+  });
+
   it('uses rollup to concat all modules in a file', () => {
     let plugins = [
       generatePlugin('plugin-a', 'builder-test/rollup/plugin-a'),
@@ -73,10 +94,10 @@ describe('Service Worker Builder', () => {
 (function () {
   'use strict';
 
-  const CONSTANT = 42;
+  var CONSTANT = 42;
 
-  self.addEventListener('fetch', function() {
-    let x = CONSTANT + 1;
+  self.addEventListener('fetch', function () {
+    var x = CONSTANT + 1;
   });
 
 }());


### PR DESCRIPTION
This PR brings back broccoli-babel-transpiler
on all builds but will force the sw.js file to change on
each rebuild thus busting the cache and ensuring the file is regenerated
properly.

This also uses the same cache key implementation that
broccoli-babel-transpiler uses.

Rely more on interpolation for module builder rather than rollup
replacement

/cc @rwjblue 