### PR TITLE
Add guard for missing addon.pkg

### DIFF
--- a/lib/addon-utils.js
+++ b/lib/addon-utils.js
@@ -1,9 +1,11 @@
-const hasKeyword = (addon, keyword) => addon.pkg.keywords.indexOf(keyword) > -1;
+const hasKeyword = (addon, keyword) =>
+  (addon.pkg && addon.pkg.keywords) && addon.pkg.keywords.indexOf(keyword) > -1;
 
 const filterByKeyword = (addons, keyword) =>
   addons.filter((addon) => hasKeyword(addon, keyword));
 
-const getName = (addon) => (addon.pkg && addon.pkg.name) || addon.name;
+const getName = (addon) =>
+  (addon.pkg && addon.pkg.name) || addon.name;
 
 module.exports = {
   filterByKeyword,


### PR DESCRIPTION
When I ran my ember 2.15.0 application using ember-service-worker + https://github.com/isleofcode/corber, it crashed with

```
   at EmberApp.addonPostprocessTree (/Users/xxx/app/node_modules/ember-cli/lib/broccoli/ember-app.js:600:12)
  name: 'EmberCordovaError',
  message: 'EmberCordovaError: Cannot read property \'keywords\' of undefined',
  stack: '    at hasKeyword (/Users/xxx/app/node_modules/ember-service-worker/lib/addon-utils.js:1:111)
```

this guard fixes it.