### PR TITLE
Add a message handler to skipWaiting based on user events

### DIFF
--- a/lib/index-file.js
+++ b/lib/index-file.js
@@ -45,24 +45,28 @@ module.exports = class Config extends Plugin {
       module += PROJECT_VERSION_STRATEGY;
     }
 
-    if (!('immediateClaim' in options) || options.immediateClaim === true) {
+    let implicitImmediateClaim = !('immediateClaim' in options);
+    let explicitImmediateClaim = !implicitImmediateClaim && options.immediateClaim === true;
+    let skipWaiting = ('skipWaitingOnMessage' in options && options.skipWaitingOnMessage === true);
+
+    if (implicitImmediateClaim || explicitImmediateClaim) {
       module += `
         self.addEventListener('install', function installEventListenerCallback(event) {
           return self.skipWaiting();
         });
-
-        self.addEventListener('activate', function installEventListenerCallback(event) {
-          return self.clients.claim();
-        });
       `;
-    } else if ('skipWaitingOnMessage' in options && options.skipWaitingOnMessage === true) {
+    }
+    if (!explicitImmediateClaim && skipWaiting) {
       module += `
         self.addEventListener('message', function skipWaitingMessageCallback(event) {
           if (event.data === 'skipWaiting') {
             return self.skipWaiting();
           }
         });
-
+      `;
+    }
+    if (implicitImmediateClaim || explicitImmediateClaim || skipWaiting) {
+      module += `
         self.addEventListener('activate', function installEventListenerCallback(event) {
           return self.clients.claim();
         });

--- a/lib/index-file.js
+++ b/lib/index-file.js
@@ -15,6 +15,23 @@ function baseModule(options) {
 const EVERY_BUILD_STRATEGY = `self.CACHE_BUSTER = VERSION;`;
 const PROJECT_REVISION_STRATEGY = `self.CACHE_BUSTER = PROJECT_REVISION;`;
 const PROJECT_VERSION_STRATEGY = `self.CACHE_BUSTER = PROJECT_VERSION;`;
+const INSTALL_EVENT_LISTENER = `
+  self.addEventListener('install', function installEventListenerCallback(event) {
+    return self.skipWaiting();
+  });
+`;
+const IMMEDIATE_CLAIM_LISTENER = `
+  self.addEventListener('message', function skipWaitingMessageCallback(event) {
+    if (event.data === 'skipWaiting') {
+      return self.skipWaiting();
+    }
+  });
+`;
+const SKIP_WAITING_LISTENER = `
+  self.addEventListener('activate', function installEventListenerCallback(event) {
+    return self.clients.claim();
+  });
+`;
 
 module.exports = class Config extends Plugin {
   constructor(inputNodes, options) {
@@ -45,34 +62,19 @@ module.exports = class Config extends Plugin {
       module += PROJECT_VERSION_STRATEGY;
     }
 
-    let implicitImmediateClaim = !('immediateClaim' in options);
-    let explicitImmediateClaim = !implicitImmediateClaim && options.immediateClaim === true;
-    let skipWaiting = ('skipWaitingOnMessage' in options && options.skipWaitingOnMessage === true);
+    const implicitImmediateClaim = !('immediateClaim' in options);
+    const explicitImmediateClaim = !implicitImmediateClaim && options.immediateClaim === true;
+    const skipWaiting = ('skipWaitingOnMessage' in options && options.skipWaitingOnMessage === true);
 
     if (implicitImmediateClaim || explicitImmediateClaim) {
-      module += `
-        self.addEventListener('install', function installEventListenerCallback(event) {
-          return self.skipWaiting();
-        });
-      `;
+      module += INSTALL_EVENT_LISTENER;
     }
     if (!explicitImmediateClaim && skipWaiting) {
-      module += `
-        self.addEventListener('message', function skipWaitingMessageCallback(event) {
-          if (event.data === 'skipWaiting') {
-            return self.skipWaiting();
-          }
-        });
-      `;
+      module += IMMEDIATE_CLAIM_LISTENER;
     }
     if (implicitImmediateClaim || explicitImmediateClaim || skipWaiting) {
-      module += `
-        self.addEventListener('activate', function installEventListenerCallback(event) {
-          return self.clients.claim();
-        });
-      `;
+      module += SKIP_WAITING_LISTENER;
     }
-    
 
     fs.writeFileSync(path.join(this.outputPath, 'index.js'), module);
   }

--- a/lib/index-file.js
+++ b/lib/index-file.js
@@ -55,7 +55,20 @@ module.exports = class Config extends Plugin {
           return self.clients.claim();
         });
       `;
+    } else if ('skipWaitingOnMessage' in options && options.skipWaitingOnMessage === true) {
+      module += `
+        self.addEventListener('message', function skipWaitingMessageCallback(event) {
+          if (event.data === 'skipWaiting') {
+            return self.skipWaiting();
+          }
+        });
+
+        self.addEventListener('activate', function installEventListenerCallback(event) {
+          return self.clients.claim();
+        });
+      `;
     }
+    
 
     fs.writeFileSync(path.join(this.outputPath, 'index.js'), module);
   }


### PR DESCRIPTION
This makes it straightforward to cause a refresh of the worker from
something like a popup banner where user input should be the trigger to
start the process. Ideally this would be included by default, but as it might conflict with identical implementations I put it in it's own block. Maybe that could change in a BC breaking version.

In an app that might look like

```
actions: {
 async click() {
   if ('serviceWorker' in navigator) {
	const reg = await navigator.serviceWorker.getRegistration();
	reg.waiting.postMessage('skipWaiting');
   }
 }
}
```

Duplicates the activate listener in the immediateClaim block since I believe it is
relevant in both places, but otherwise this change is incompatible with immediateClaim they essentially do opposite things.