### PR TITLE
Use HTML comment for inline registration placeholder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - npm install -g bower
 
 install:
-  - cd node-tests/fixtures/simple-app && npm install && bower install && cd -
+  - cd node-tests/fixtures/simple-app && npm install $(npm pack ../../..) && npm install && bower install && cd -
   - npm install
 
 script:

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ module.exports = {
       }
 
       if (options.registrationStrategy === 'inline') {
-        return `<script>ESW_INLINE_PLACEHOLDER</script>`;
+        return `<!-- ESW_INLINE_PLACEHOLDER -->`;
       }
     }
 

--- a/lib/inline-registration.js
+++ b/lib/inline-registration.js
@@ -18,7 +18,7 @@ constructor(inputNodes, options) {
     let indexHtml = fs.readFileSync(path.join(this.inputPaths[0], 'index.html')).toString();
     let swRegistration = fs.readFileSync(path.join(this.inputPaths[1], 'sw-registration.js')).toString();
 
-    indexHtml = indexHtml.replace('ESW_INLINE_PLACEHOLDER', swRegistration);
+    indexHtml = indexHtml.replace('<!-- ESW_INLINE_PLACEHOLDER -->', () => `<script>${swRegistration}</script>`);
 
     fs.writeFileSync(path.join(this.outputPath, 'index.html'), indexHtml);
   }


### PR DESCRIPTION
* Use an HTML comment as a placeholder which is in step with [ember-fastboot's tag replacement approach](https://github.com/ember-fastboot/fastboot/blob/4568734c0c4b8ea33b0e07e33eb9bbd98fa0a1e3/src/result.js#L180), and helps with issues like #99 (repro with `http://localhost:4200/tests` case)
* Use a function (vs a string) value for replacement protects against those "[special replacement patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter)" bugs cropping up later
* Pack up add-on before installing fixture dependencies for CI to work around dependency link recursion during hash generation (mentioned in https://github.com/DockYard/ember-service-worker/pull/96#issuecomment-386095601)