### PR TITLE
Fix acceptance test recursive installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+/node-tests/fixtures/simple-app/ember-service-worker.tgz
 
 # jekyll docs
 /docs/_site

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - npm install -g bower
 
 install:
-  - cd node-tests/fixtures/simple-app && npm install $(npm pack ../../..) && npm install && bower install && cd -
   - npm install
 
 script:

--- a/node-tests/fixtures/simple-app/package.json
+++ b/node-tests/fixtures/simple-app/package.json
@@ -10,9 +10,11 @@
   },
   "repository": "",
   "scripts": {
+    "preinstall": "npm run update-package",
     "build": "ember build",
     "start": "ember server",
-    "test": "ember test"
+    "test": "ember test",
+    "update-package": "mv $(npm pack ../../..) ember-service-worker.tgz"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -33,7 +35,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-service-worker": "file:../../..",
+    "ember-service-worker": "file:ember-service-worker.tgz",
     "ember-source": "~2.12.0",
     "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "scripts": {
+    "pretest": "cd node-tests/fixtures/simple-app && npm run update-package && npm install ember-service-worker.tgz",
     "test": "mocha node-tests",
     "fastboottest": "ember fastboot:test"
   },


### PR DESCRIPTION
Per this [comment](https://github.com/DockYard/ember-service-worker/pull/96#issuecomment-386095601) this PR addresses the installation issues that prevent the acceptance tests from running. I think it could unblock the babel upgrade changes.