### PR TITLE
Fix for ROOT_URL not getting replaced

### DIFF
--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -85,7 +85,7 @@ module.exports = class ServiceWorkerBuilder {
 
   _rollupTree(tree, entryFile, destFile) {
     let rollupReplaceConfig = {
-      include: ['**/ember-service-worker/**/*.js'],
+      include: ['/**/ember-service-worker/**/*.js'],
       delimiters: ['{{', '}}'],
       ROOT_URL: this.options.rootURL
     };


### PR DESCRIPTION
I don't know what impacts this new glob pattern has, because I feel like it changes the behavior of the glob, looking for files at the root of the machine.

I made this change in emberclear's node_modules, and I correctly had a proper sw path. so..... :man_shrugging: 

This 'fixes' #125
