### PR TITLE
Validate version strategy and fall back when invalid/not provided

### DIFF
--- a/lib/index-file.js
+++ b/lib/index-file.js
@@ -4,6 +4,12 @@ const fs = require('fs');
 const path = require('path');
 const Plugin = require('broccoli-plugin');
 
+const VERSION_STRATEGIES = {
+  EVERY_BUILD: 'every-build',
+  PROJECT_REVISION: 'project-revision',
+  PROJECT_VERSION: 'project-version'
+};
+
 function baseModule(options) {
   return `
     export const PROJECT_VERSION = '${options.projectVersion}';
@@ -48,17 +54,18 @@ module.exports = class Config extends Plugin {
     options.buildTime = (new Date).getTime() + '|' + Math.random();
 
     let module = baseModule(options);
-    let versionStrategy = options.versionStrategy;
+    let validVersionStrategies = [VERSION_STRATEGIES.EVERY_BUILD, VERSION_STRATEGIES.PROJECT_REVISION, VERSION_STRATEGIES.PROJECT_VERSION];
+    let versionStrategy = validVersionStrategies.indexOf(options.versionStrategy) !== -1 ? options.versionStrategy : VERSION_STRATEGIES.EVERY_BUILD;
 
-    if (!('versionStrategy' in options) || options.versionStrategy === 'every-build') {
+    if (versionStrategy === VERSION_STRATEGIES.EVERY_BUILD) {
       module += EVERY_BUILD_STRATEGY;
     }
 
-    if (options.versionStrategy === 'project-revision') {
+    if (versionStrategy === VERSION_STRATEGIES.PROJECT_REVISION) {
       module += PROJECT_REVISION_STRATEGY;
     }
 
-    if (options.versionStrategy === 'project-version') {
+    if (versionStrategy === VERSION_STRATEGIES.PROJECT_VERSION) {
       module += PROJECT_VERSION_STRATEGY;
     }
 


### PR DESCRIPTION
Specifying an invalid version strategy (like camel casing instead of hyphenated) prevents any cache buster value from being used. This approach uses the default if the provided value is invalid.