### PR TITLE
Ensure existing babel options are preserved when compiling - fixes #133

### DIFF
--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -116,6 +116,8 @@ module.exports = class ServiceWorkerBuilder {
 
   _babelTranspile(tree) {
     let emberCliBabel = this.app.project.addons.filter((a) => a.name === 'ember-cli-babel')[0];
-    return emberCliBabel.transpileTree(tree, { 'ember-cli-babel': { compileModules: false } });
+    let options = emberCliBabel.buildBabelOptions();
+    options.compileModules = false;
+    return emberCliBabel.transpileTree(tree, { 'ember-cli-babel': options });
   }
 }


### PR DESCRIPTION
Fixes #133 to enable existing babel configuration to be passed along. Still needs validation and tests.