### PR TITLE
added the regular expression for windows paths

### DIFF
--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -87,6 +87,9 @@ module.exports = class ServiceWorkerBuilder {
     let rollupReplaceConfig = {
       include: [
         '/**/ember-service-worker/**/*.js',
+        // same as above but for windows paths like D:\my-ember\ember-service-worker\whatever\sw.js;
+        // the original one doesn't work when the source code and the %TMP% folder, which ember started to use after v3.5, are located on different logical drives
+        // which is quite common in Windows.
         /^[a-z]:\/(?:[^\/:*?"<>|\r\n]+\/)*ember-service-worker\/(?:[^\/:*?"<>|\r\n]+\/)*[^\/:*?"<>|\r\n]*\.js$/i
       ],
       delimiters: ['{{', '}}'],

--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -87,7 +87,7 @@ module.exports = class ServiceWorkerBuilder {
     let rollupReplaceConfig = {
       include: [
         '/**/ember-service-worker/**/*.js',
-        // same as above but for windows paths like D:\my-ember\ember-service-worker\whatever\sw.js;
+        // same as above but for windows paths like D:\my-ember\ember-service-worker\whatever\sw.js; which are updated before this step to D:/my-ember/ember-service/worker/whatever/sw.js
         // the original one doesn't work when the source code and the %TMP% folder, which ember started to use after v3.5, are located on different logical drives
         // which is quite common in Windows.
         /^[a-z]:\/(?:[^\/:*?"<>|\r\n]+\/)*ember-service-worker\/(?:[^\/:*?"<>|\r\n]+\/)*[^\/:*?"<>|\r\n]*\.js$/i

--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -85,7 +85,10 @@ module.exports = class ServiceWorkerBuilder {
 
   _rollupTree(tree, entryFile, destFile) {
     let rollupReplaceConfig = {
-      include: ['/**/ember-service-worker/**/*.js'],
+      include: [
+        '/**/ember-service-worker/**/*.js',
+        /^[a-z]:\/(?:[^\/:*?"<>|\r\n]+\/)*ember-service-worker\/(?:[^\/:*?"<>|\r\n]+\/)*[^\/:*?"<>|\r\n]*\.js$/i
+      ],
       delimiters: ['{{', '}}'],
       ROOT_URL: this.options.rootURL
     };


### PR DESCRIPTION
Fixes #142. 
Addresses #125.

The fix adds another `include` filter which contains a Windows path regular expression. I took the expression from [here](https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s18.html), replaced `\` with `/` and added `ember-service-worker` and `.js` like in the glob pattern. 

In theory this should not interfere with the glob expression which will work like it did before and should only cover the case described in #142.