### PR TITLE
Update rollup output export options to 1.0+ syntax

### DIFF
--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -103,8 +103,8 @@ module.exports = class ServiceWorkerBuilder {
         output: {
           file: destFile || entryFile,
           format: 'iife',
+          exports: 'none',
         },
-        exports: 'none',
         plugins: [
           rollupReplace(rollupReplaceConfig)
         ]


### PR DESCRIPTION
https://github.com/DockYard/ember-service-worker/blob/master/lib/service-worker-builder.js#L107 emmits the following Rollup deprecation notice:

```sh
The following options have been renamed — please update your config: exports -> output.exports
```

Because Rollup moved the `options.exports` to `options.output.exports` on 1.0, as stated on this PR: https://github.com/rollup/rollup/pull/2293.

Moving the `exports` setting accordingly removes the warning.

I did not think new/modified tests were necessary for this change (?).