### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/_documentation/configuration.md
+++ b/docs/_documentation/configuration.md
@@ -118,7 +118,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     'ember-service-worker': {
-      serviceWorkerFileName: 'customfilename.js'
+      serviceWorkerFilename: 'customfilename.js'
     }
   });
 


### PR DESCRIPTION
There's a typo in the documentation regarding the `serviceWorkerFilename` that's fixed by this PR :)