### PR TITLE
Fix createAbsoluteDomain method name

### DIFF
--- a/service-worker/url-utils.js
+++ b/service-worker/url-utils.js
@@ -34,7 +34,7 @@ export function urlMatchesAnyPattern(url, patterns) {
 }
 
 export default {
-  createAbsoluteDomain,
+  createNormalizedUrl,
   createUrlRegEx,
   urlMatchesAnyPattern
 }


### PR DESCRIPTION
Fix createAbsoluteDomain method name which causes sw.js:138 Uncaught ReferenceError: createAbsoluteDomain is not defined.