### PR TITLE
Remove preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "tests"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
     "test": "mocha node-tests",
     "lint:js": "eslint ."
   },


### PR DESCRIPTION
Fixes #185 but leaves the dependency on clean-css not resolving to the later version.
To address in a follow-up but this will allow installation again.