### PR TITLE
Ignore Service Worker Registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ module.exports = {
       rootURL: this._getRootURL(),
       sourcemaps: this.app.options.sourcemaps,
       registrationDistPath: options.registrationDistPath,
-      serviceWorkerFilename: options.serviceWorkerFilename
+      serviceWorkerFilename: options.serviceWorkerFilename,
+      ignoreRegistration: options.ignoreRegistration
     });
 
     let serviceWorkerTree = serviceWorkerBuilder.build('service-worker');

--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -89,7 +89,8 @@ module.exports = class ServiceWorkerBuilder {
       ],
       delimiters: ['{{', '}}'],
       ROOT_URL: this.options.rootURL,
-      SERVICE_WORKER_FILENAME: this.options.serviceWorkerFilename
+      SERVICE_WORKER_FILENAME: this.options.serviceWorkerFilename,
+      IGNORE_REGISTRATION: this.options.ignoreRegistration
     };
 
     return new Rollup(tree, {

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -5,10 +5,9 @@ let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
   if ('{{IGNORE_REGISTRATION}}' === 'true') {
-    return
-  }
-
-  navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
+    console.log('registrationIgnored');
+  } else {
+    navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {
       let current = Promise.resolve();
 
@@ -37,6 +36,7 @@ if ('serviceWorker' in navigator) {
           console.log('Service Worker registration failed with ' + error);
         });
     });
+  }
 }
 
 

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,7 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  if ('{{IGNORE_REGISTRATION}}' === 'true') return;
+  console.log('{{IGNORE_REGISTRATION}}' === 'true')
 
   navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,7 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  console.log({{IGNORE_REGISTRATION}});
+  console.log('{{IGNORE_REGISTRATION}}');
   navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {
       let current = Promise.resolve();

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,35 +4,7 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
-    .then(function(reg) {
-      let current = Promise.resolve();
-
-      for (let i = 0, len = SUCCESS_HANDLERS.length; i < len; i++) {
-        current = current.then(function() {
-          return SUCCESS_HANDLERS[i](reg);
-        });
-      }
-
-      return current
-        .then(function() {
-          console.log('Service Worker registration succeeded. Scope is ' + reg.scope);
-        });
-    })
-    .catch(function(error) {
-      let current = Promise.resolve();
-
-      for (let i = 0, len = ERROR_HANDLERS.length; i < len; i++) {
-        current = current.then(function() {
-          return ERROR_HANDLERS[i](error);
-        });
-      }
-
-      return current
-        .then(function() {
-          console.log('Service Worker registration failed with ' + error);
-        });
-    });
+  console.log('que lo que?');
 }
 
 

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,7 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  console.log('{{IGNORE_REGISTRATION}}' === 'true')
+  if ('{{IGNORE_REGISTRATION}}' === 'true') return
 
   navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,8 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  console.log('{{IGNORE_REGISTRATION}}');
+  if ('{{IGNORE_REGISTRATION}}' === 'true') return;
+
   navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {
       let current = Promise.resolve();

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,36 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  console.log('que lo que?');
+  console.log('{{IGNORE_REGISTRATION}}');
+  navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
+    .then(function(reg) {
+      let current = Promise.resolve();
+
+      for (let i = 0, len = SUCCESS_HANDLERS.length; i < len; i++) {
+        current = current.then(function() {
+          return SUCCESS_HANDLERS[i](reg);
+        });
+      }
+
+      return current
+        .then(function() {
+          console.log('Service Worker registration succeeded. Scope is ' + reg.scope);
+        });
+    })
+    .catch(function(error) {
+      let current = Promise.resolve();
+
+      for (let i = 0, len = ERROR_HANDLERS.length; i < len; i++) {
+        current = current.then(function() {
+          return ERROR_HANDLERS[i](error);
+        });
+      }
+
+      return current
+        .then(function() {
+          console.log('Service Worker registration failed with ' + error);
+        });
+    });
 }
 
 

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,7 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  console.log('{{IGNORE_REGISTRATION}}');
+  console.log({{IGNORE_REGISTRATION}});
   navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {
       let current = Promise.resolve();

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,9 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  if ('{{IGNORE_REGISTRATION}}' === 'true') return
+  if ('{{IGNORE_REGISTRATION}}' === 'true') {
+    return
+  }
 
   navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
     .then(function(reg) {


### PR DESCRIPTION
## Why?

For my use case, I need to manually register the service worker only if certain conditions are met, for this, I passed a flag to avoid that the plugin registers the service worker, and I register in another place on my app.

## How it works?

in your ember-cli-build you pass

'ember-service-worker': {
        ignoreRegistration: true
}

and the plugin will not register the service worker, allowing you to do the registration manually in your app.